### PR TITLE
Fixes issue with nested lists not render properly

### DIFF
--- a/src/markdown-embedder.js
+++ b/src/markdown-embedder.js
@@ -9,7 +9,7 @@ Array.prototype.forEach.call(document.getElementsByClassName('g-embed'), element
     });
     let converter = (text) => {
         return new Promise((resolve, reject) => {
-            let converted = new showdown.Converter().makeHtml(text);
+            let converted = new showdown.Converter({disableForced4SpacesIndentedSublists: true}).makeHtml(text);
             resolve(converted);
         });
     }


### PR DESCRIPTION
I founder this bug that prevents lists nested using double spaces from rendering properly. It seems like it's an easy fix:
https://github.com/showdownjs/showdown/issues/367